### PR TITLE
fix: don't let bcc recipients end up in 'to'.

### DIFF
--- a/flask_mailgun/api.py
+++ b/flask_mailgun/api.py
@@ -37,7 +37,7 @@ class MailGunAPI(object):
         :param envelope_from: Email address to be used in MAIL FROM command.
         """
         mesage_data = {'from': envelope_from or message.sender,
-                       'to': message.send_to,
+                       'to': message.recipients,
                        'subject': message.subject,
                        "cc": message.cc,
                        "bcc": message.bcc,

--- a/flask_mailgun/message.py
+++ b/flask_mailgun/message.py
@@ -71,10 +71,6 @@ class Message(object):
         self.attachments = attachments or []
 
     @property
-    def send_to(self):
-        return set(self.recipients) | set(self.bcc or ()) | set(self.cc or ())
-
-    @property
     def html(self):
         return self.alts.get('html')
 

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -27,9 +27,9 @@ class SendMessageTest(MailgunTestBase):
         self.assertEqual(auth, ('api', b'testtesttest'))
         # self.assertEqual(files, [])
         self.assertEqual(data['from'], message.sender)
-        self.assertEqual(data['to'], set(message.recipients))
-        self.assertEqual(data['bcc'], set(message.bcc))
-        self.assertEqual(data['cc'], set())
+        self.assertEqual(data['to'], message.recipients)
+        self.assertEqual(data['bcc'], message.bcc)
+        self.assertEqual(data['cc'], [])
         self.assertEqual(data['subject'], message.subject)
         self.assertEqual(data['text'], message.body)
 

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -15,6 +15,7 @@ class SendMessageTest(MailgunTestBase):
         message = Message(subject="Hello",
                           sender="from@example.com",
                           recipients=["u1@example.com", "u2@example.com"],
+                          bcc=["foo@bar.com"],
                           body="Testing some Mailgun awesomness!")
         self.mailgun.send(message)
         self.assertTrue(self.mock_post.called)
@@ -27,6 +28,8 @@ class SendMessageTest(MailgunTestBase):
         # self.assertEqual(files, [])
         self.assertEqual(data['from'], message.sender)
         self.assertEqual(data['to'], set(message.recipients))
+        self.assertEqual(data['bcc'], set(message.bcc))
+        self.assertEqual(data['cc'], set())
         self.assertEqual(data['subject'], message.subject)
         self.assertEqual(data['text'], message.body)
 


### PR DESCRIPTION
Didn't really dive into the details, but I think at least this PR uncovers a bug where bcc recipients end up not being hidden as they're supposed to.