### PR TITLE
Renamed `async` names to avoid reserved word faults in Python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,16 @@ mailgun.send(message)
 
 ## Long Requests
 
-A mechanisom has been put in place to simplify handling long requests. Basically if your callback function blocks the processing of an email for toolong it will cause the post from the mailgun services to timeout. At the moment this is done by setting the `mailgun.callback_handeler` to `mailgun.async` but you would have to do this before registering the callbacks (you could reregister on init as well).
+A mechanisom has been put in place to simplify handling long requests. Basically if your callback function blocks the processing of an email for toolong it will cause the post from the mailgun services to timeout. At the moment this is done by setting the `mailgun.callback_handeler` to `mailgun.async_pool` but you would have to do this before registering the callbacks (you could reregister on init as well).
 ```python
 # at config
 app.config['MAILGUN_BG_PROCESSES'] = flask_mailgun.processing.async_pool(NO_PROCS)
 app.config['MAILGUN_CALLBACK_HANDELER'] = app.config['MAILGUN_BG_PROCESSES']
 # or later
-mailgun.callback_handeler = mailgun.async
+mailgun.callback_handeler = mailgun.async_pool
 
 # but you may still have to :(
-mailgun._on_attachment = [mailgun.async(func) for func in mailgun._on_attachment]
+mailgun._on_attachment = [mailgun.async_pool(func) for func in mailgun._on_attachment]
 ```
 
 Async will save the attachment to disk and offload your callback to a process pool, handling all the file opperations and file cleanup for you.

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ A mechanisom has been put in place to simplify handeling long requests.
 Basically if your callback function blocks the processing of an email
 for toolong it will cause the post from the mailgun services to timeout.
 At the moment this is done by setting the ``mailgun.callback_handeler``
-to ``mailgun.async`` but you would have to do this before registering
+to ``mailgun.async_pool`` but you would have to do this before registering
 the callbacks (you could reregister on init as well).
 
 .. code:: python
@@ -64,10 +64,10 @@ the callbacks (you could reregister on init as well).
     app.config['MAILGUN_BG_PROCESSES'] = flask_mailgun.processing.async_pool(NO_PROCS)
     app.config['MAILGUN_CALLBACK_HANDELER'] = app.config['MAILGUN_BG_PROCESSES']
     # or later
-    mailgun.callback_handeler = mailgun.async
+    mailgun.callback_handeler = mailgun.async_pool
 
     # but you may still have to :(
-    mailgun._on_attachment = [mailgun.async(func) for func in mailgun._on_attachment]
+    mailgun._on_attachment = [mailgun.async_pool(func) for func in mailgun._on_attachment]
 
 Async will save the attachment to disk and offload your callback to a
 process pool, handeling all the file opperations and file cleanup for

--- a/flask_mailgun/processing.py
+++ b/flask_mailgun/processing.py
@@ -27,6 +27,6 @@ class Processor:
     def init_app(self, app):   
         self.callback_handeler = app.config.get('MAILGUN_CALLBACK_HANDELER',
                                                 sync)
-        self.async = async_pool(app.config.get('MAILGUN_BG_PROCESSES', 4))
+        self.async_pool = async_pool(app.config.get('MAILGUN_BG_PROCESSES', 4))
 
         self.process = self.callback_handeler

--- a/tests/test_receve.py
+++ b/tests/test_receve.py
@@ -7,8 +7,11 @@ Created on Fri Apr 21 14:05:26 2017
 from __future__ import print_function
 import unittest
 import time
+import json
 from flask_mailgun.utils import MailGunException
 from mock import MagicMock
+
+from collections import namedtuple
 
 from tests import MailgunTestBase
 from tests.fixtures.email import make_email_request, make_email, sign_email
@@ -81,7 +84,7 @@ class ReceiveMessageAsyncTest(ReceiveMessageCallbacksTest):
         self.email1 = make_email_request(self.mailgun)
         self.email2 = make_email_request(self.mailgun)
         # re register callbacks as async
-        self.mailgun.callback_handeler = self.mailgun.processor.async
+        self.mailgun.callback_handeler = self.mailgun.processor.async_pool
         callbacks = self.mailgun._on_attachment
         self.mailgun._on_attachment = []
         for callback in callbacks:


### PR DESCRIPTION
Small tweaks to support python 3.7, which starts to enforce reserved word usage.

All tests pass.