### PR TITLE
Add necessary skips to .travis.yml for PyPi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ after_success:
 - coveralls
 - codeclimate-test-reporter
 deploy:
+  skip_cleanup: true
+  skip_existing: true
   provider: pypi
   user: RichardMathie
   password:


### PR DESCRIPTION
The `skip_cleanup` will fix the removal of the build artifacts
The `skip_existing` will fix the next issue that since you have multiple builds for each python version, they will all try to deploy individually, causing an "existing application" error on PyPi side. This will allow one to succeed and the other to skip if it already exists.

Fixes #28 