### PR TITLE
Moves the production dependencies to the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,6 @@ Flask-MailGun
 Flask extension to use the Mailgun email parsing service
 for sending and receving emails
 """
-try: # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
-    from pip.req import parse_requirements
 from io import open
 try:
     from setuptools import setup
@@ -22,9 +18,6 @@ with open('Version', encoding='utf-8') as f:
 with open('README.rst', encoding='utf-8') as f:
     readme = f.read()
 
-# parse_requirements() returns generator of pip.req.InstallRequirement objects
-requirements = parse_requirements('requirements.txt', session=False)
-requirements = [str(ir.req) for ir in requirements]
 
 __NAME__ = 'Flask-MailGun3'
 __doc__ = readme
@@ -44,7 +37,11 @@ setup(
     download_url='https://github.com/amey-sam/Flask-MailGun/tarball/master',
     # py_modules=['flask_mailgun'],
     packages=['flask_mailgun'],
-    install_requires=requirements,
+    install_requires=[
+      'Flask',
+      'requests',
+      'decorator',
+    ],
     keywords=['flask', 'mailgun'],
     zip_safe=False,
     platforms='any',
@@ -56,6 +53,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]


### PR DESCRIPTION
The existing setup.py was relying on pip's internal parsing tools to parse requirements from the requirements.txt. It would seem that pip has [recently updated](https://github.com/pypa/pip/issues/8188#issuecomment-623428010) that such that the existing implementation no longer works on newer versions of pip. This update moves the production dependencies to the setup.py. 