### PR TITLE
Fix installation on Pip > 20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ try: # for pip >= 10
     from pip._internal.req import parse_requirements
 except ImportError: # for pip <= 9.0.3
     from pip.req import parse_requirements
+
 from io import open
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
-
 
 with open('Version', encoding='utf-8') as f:
     version = next(f).strip()
@@ -23,8 +23,12 @@ with open('README.rst', encoding='utf-8') as f:
     readme = f.read()
 
 # parse_requirements() returns generator of pip.req.InstallRequirement objects
-requirements = parse_requirements('requirements.txt', session=False)
-requirements = [str(ir.req) for ir in requirements]
+requirements = list(parse_requirements('requirements.txt', session=False))
+try:
+    requirements = [str(ir.req) for ir in requirements]
+except AttributeError:
+    # pip > 20
+    requirements = [str(ir.requirement) for ir in requirements]
 
 __NAME__ = 'Flask-MailGun3'
 __doc__ = readme


### PR DESCRIPTION
The objects returned by the Pip's `parse_requirements` no longer have a `.req` attribute after Pip 20.

This patch tries to use `.req`, and falls back to the new `.requirement` name.

This is basically doing the same as #26, except using `requirements.txt` instead of hard-coding the requirements in `setup.py`.
